### PR TITLE
Suppress a new Jammy warning

### DIFF
--- a/test/integration/factory.cc
+++ b/test/integration/factory.cc
@@ -115,7 +115,7 @@ TEST(Factory, Alias)
 
   EXPECT_FALSE(symbolName.empty());
 
-  for (const std::string &alias : {
+  for (auto alias : {
        symbolName.c_str(),
        "test::util::SomeObjectAddTwo",
        "This factory has an alias",


### PR DESCRIPTION
```
/home/mjcarroll/workspaces/gz_garden/src/gz-plugin/test/integration/factory.cc: In member function ‘virtual void Factory_Alias_Test::TestBody()’:
/home/mjcarroll/workspaces/gz_garden/src/gz-plugin/test/integration/factory.cc:118:27: warning: loop variable ‘alias’ of type ‘const string&’ {aka ‘const std::__cxx11::basic_string<char>&’} binds to a temporary constructed from type ‘const char* const’ [-Wrange-loop-construct]
  118 |   for (const std::string &alias : {
      |                           ^~~~~
/home/mjcarroll/workspaces/gz_garden/src/gz-plugin/test/integration/factory.cc:118:27: note: use non-reference type ‘const string’ {aka ‘const std::__cxx11::basic_string<char>’} to make the copy explicit or ‘const char* const&’ to prevent copying
```

Signed-off-by: Michael Carroll <michael@openrobotics.org>