### PR TITLE
Clean unused lambda capture warning

### DIFF
--- a/loader/src/cmd/plugin_main.cc
+++ b/loader/src/cmd/plugin_main.cc
@@ -72,7 +72,7 @@ void addPluginFlags(CLI::App &_app)
        opt->command = PluginCommand::kPluginInfo;
      }, "Get info about a plugin.")->needs(plugin);
 
-  _app.callback([&_app, opt](){
+  _app.callback([opt](){
     runPluginCommand(*opt);
   });
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Remove an "unused capture" warning from the CLI lambda.

## Checklist
- [x] Signed all commits for DCO
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.