### PR TITLE
Inline functions in plugin_unload.hh

### DIFF
--- a/test/integration/plugin_unload.hh
+++ b/test/integration/plugin_unload.hh
@@ -33,7 +33,7 @@
 /// \brief Load the InstanceCounter plugin
 /// \param[in] _nodelete True if RTLD_NODELETE should be used when loading the
 /// \return Pointer to the plugin
-gz::plugin::PluginPtr LoadInstanceCounter(bool _nodelete)
+inline gz::plugin::PluginPtr LoadInstanceCounter(bool _nodelete)
 {
   gz::plugin::Loader pl;
 
@@ -50,7 +50,8 @@ gz::plugin::PluginPtr LoadInstanceCounter(bool _nodelete)
 /// \param[in] _nodelete True if RTLD_NODELETE should be used when loading the
 /// library.
 /// \param[in] _numExpectedInstances Expected number of instances of the plugin.
-void LoadAndTestInstanceCounter(bool _nodelete, int _numExpectedInstances)
+inline void LoadAndTestInstanceCounter(bool _nodelete,
+                                       int _numExpectedInstances)
 {
   gz::plugin::PluginPtr instanceCounterPlugin = LoadInstanceCounter(_nodelete);
   test::util::InstanceCounterBase *instanceCounter =


### PR DESCRIPTION
Prevents ODR violation errors in case we include the header in two different translation units compiled into the same test in future.