### PR TITLE
Remove Windows 7 and align with other README.md's

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Build | Status
 Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-plugin/branch/main/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-plugin/branch/main)
 Ubuntu Focal | [![Build Status](https://build.osrfoundation.org/job/ignition_plugin-ci-main-focal-amd64/badge/icon)](https://build.osrfoundation.org/job/ignition_plugin-ci-main-focal-amd64/)
 Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_plugin-ci-main-homebrew-amd64)](https://build.osrfoundation.org/job/ignition_plugin-ci-main-homebrew-amd64)
-Windows     | [![Build Status](https://build.osrfoundation.org/job/ignition_plugin-ci-main-windows7-amd64/badge/icon)](https://build.osrfoundation.org/job/ignition_plugin-ci-main-windows7-amd64/)
+Windows     | [![Build Status](https://build.osrfoundation.org/view/ign-garden/job/ign_plugin-gz-2-win/badge/icon)](https://build.osrfoundation.org/view/ign-garden/job/ign_plugin-gz-2-win/)
 
 Gazebo Plugin is a component in the [Gazebo](http://gazebosim.org) framework, a set
 of libraries designed to rapidly develop robot applications.  

--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ Build | Status
 Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-plugin/branch/main/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-plugin/branch/main)
 Ubuntu Focal | [![Build Status](https://build.osrfoundation.org/job/ignition_plugin-ci-main-focal-amd64/badge/icon)](https://build.osrfoundation.org/job/ignition_plugin-ci-main-focal-amd64/)
 Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_plugin-ci-main-homebrew-amd64)](https://build.osrfoundation.org/job/ignition_plugin-ci-main-homebrew-amd64)
-Windows 7     | [![Build Status](https://build.osrfoundation.org/job/ignition_plugin-ci-main-windows7-amd64/badge/icon)](https://build.osrfoundation.org/job/ignition_plugin-ci-main-windows7-amd64/)
-
-**Library for registering plugin libraries and dynamically loading them at runtime.**
+Windows     | [![Build Status](https://build.osrfoundation.org/job/ignition_plugin-ci-main-windows7-amd64/badge/icon)](https://build.osrfoundation.org/job/ignition_plugin-ci-main-windows7-amd64/)
 
 Gazebo Plugin is a component in the [Gazebo](http://gazebosim.org) framework, a set
-of libraries designed to rapidly develop robot applications.
+of libraries designed to rapidly develop robot applications.  
+It is used to register plugin libraries and load them dynamically at runtime.
 
 [http://gazebosim.org](http://gazebosim.org)
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ It is used to register plugin libraries and load them dynamically at runtime.
 
 ## Installation
 
-See the [installation tutorial](https://gazebosim.org/api/plugin/1.2/installation.html).
+See the [installation tutorial](https://gazebosim.org/api/plugin/2/installation.html).
 
 # Documentation
 
-API documentation and tutorials can be accessed at [https://gazebosim.org/libs/plugin](https://gazebosim.org/libs/plugin)
+Visit the [documentation page](https://gazebosim.org/api/plugin/2/index.html).


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
- remove Windows 7
- align description style with other README files
- update version of links
- fix link for documentation

related to https://github.com/gazebosim/gazebo_test_cases/issues/133

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.