### PR TITLE
Do not install CMakeLists.txt in loader/register

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -54,7 +54,8 @@ endif()
 
 install(
   DIRECTORY include/
-  DESTINATION ${IGN_INCLUDE_INSTALL_DIR_FULL})
+  DESTINATION ${IGN_INCLUDE_INSTALL_DIR_FULL}
+  PATTERN "CMakeLists.txt" EXCLUDE)
 
 #============================================================================
 # ign command line support

--- a/register/CMakeLists.txt
+++ b/register/CMakeLists.txt
@@ -3,4 +3,5 @@ ign_add_component(register INTERFACE)
 
 install(
   DIRECTORY include/
-  DESTINATION ${IGN_INCLUDE_INSTALL_DIR_FULL})
+  DESTINATION ${IGN_INCLUDE_INSTALL_DIR_FULL}
+  PATTERN "CMakeLists.txt" EXCLUDE)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
By including the installation of a whole directory in the source code for loader/register, the buildsystem is installing the CMakeLists.txt files that are included in these directories. Debian packaging QA tool was complaining about it:
```
I: libignition-plugin-dev: package-contains-documentation-outside-usr-share-doc [usr/include/ignition/plugin1/CMakeLists.txt]
```

Exclude them from the final installation by using the EXCLUDE clause in CMake.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.