### PR TITLE
Enable `UNIT_gz_TEST` on Windows

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -3,7 +3,7 @@
 gz_get_libsources_and_unittests(sources tests)
 
 # Disable gz_TEST if gz-tools is not found
-if (MSVC OR NOT GZ_TOOLS_PROGRAM)
+if (NOT GZ_TOOLS_PROGRAM)
   list(REMOVE_ITEM tests src/gz_TEST.cc)
 endif()
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
https://github.com/gazebosim/gz-plugin/pull/63 fixed installing ruby files in windows, but `UNIT_gz_TEST` was still not running.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

