### PR TITLE
Remove HIDE_SYMBOLS_BY_DEFAULT: replace by a default configuration in gz-cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,6 @@ set(GZ_UTILS_VER ${gz-utils3_VERSION_MAJOR})
 # Configure the build
 #============================================================================
 gz_configure_build(QUIT_IF_BUILD_ERRORS
-  HIDE_SYMBOLS_BY_DEFAULT
   COMPONENTS loader register)
 
 


### PR DESCRIPTION
See https://github.com/gazebosim/gz-cmake/issues/166