### PR TITLE
Add bazel deps to pass layering_check

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,5 @@
 load(
     "@gz//bazel/skylark:build_defs.bzl",
-    "GZ_FEATURES",
     "GZ_ROOT",
     "GZ_VISIBILITY",
     "gz_configure_header",
@@ -10,7 +9,6 @@ load(
 
 package(
     default_visibility = GZ_VISIBILITY,
-    features = GZ_FEATURES,
 )
 
 licenses(["notice"])  # Apache-2.0
@@ -43,8 +41,8 @@ gz_include_header(
     name = "pluginhh_genrule",
     out = "core/include/gz/plugin.hh",
     hdrs = public_headers_no_gen + [
-        "core/include/gz/plugin/config.hh",
         "core/include/gz/plugin/Export.hh",
+        "core/include/gz/plugin/config.hh",
     ],
 )
 
@@ -93,6 +91,7 @@ cc_library(
     ],
     deps = [
         ":core",
+        ":loader",
     ],
 )
 
@@ -126,11 +125,15 @@ cc_library(
 
 cc_test(
     name = "Loader_TEST",
-    srcs = ["loader/src/Loader_TEST.cc"],
+    srcs = [
+        "loader/src/Loader_TEST.cc",
+        ":config",
+    ],
     defines = [
         'GzDummyPlugins_LIB=\\"./plugin/test/libGzDummyPlugins.so\\"',
     ],
     deps = [
+        ":core",
         ":loader",
         GZ_ROOT + "plugin/test:test_plugins",
         "@gtest",


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Makes gz-plugin build successfully with layering_check and parse_headers turned on. These failures are currently only detectable in Intrinsic's internal Bazel infrastructure.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.