### PR TITLE
Update gz-tools version in installation tutorial

### DIFF
--- a/tutorials/02_installation.md
+++ b/tutorials/02_installation.md
@@ -42,12 +42,12 @@ sudo apt install libgz-plugin3-dev
 
 1. Install Gazebo dependencies
   ```
-  sudo apt-get install libgz-cmake4-dev libgz-tools3-dev libgz-utils3-cli-dev
+  sudo apt-get install libgz-cmake4-dev libgz-tools2-dev libgz-utils3-cli-dev
   ```
 
 1. Install Gazebo Tools if you want to use the `gz plugin` command line tool:
   ```bash
-  sudo apt-get install gz-tools3
+  sudo apt-get install gz-tools2
   ```
 
 2. Clone the repository


### PR DESCRIPTION

# 🦟 Bug fix

Fixes #<NUMBER>

## Summary

Ionic uses gz-tools2 and not 3.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

