### PR TITLE
ci: run cppcheck, cpplint, doxygen on noble

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ jobs:
         uses: gazebo-tooling/action-gz-ci@jammy
         with:
           codecov-enabled: true
-          cppcheck-enabled: true
-          cpplint-enabled: true
-          doxygen-enabled: true
   noble-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Noble CI
@@ -32,3 +29,7 @@ jobs:
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
+        with:
+          cppcheck-enabled: true
+          cpplint-enabled: true
+          doxygen-enabled: true


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebo-tooling/release-tools/issues/1222

## Summary

Jammy isn't officially supported for Ionic, so move linters to use Noble, starting with cppcheck and cpplint.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
