### PR TITLE
Update GZ_TOOLS_VER to 2 in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ gz_find_package(DL
 #--------------------------------------
 # Find gz-tools
 find_program(GZ_TOOLS_PROGRAM gz)
-set(GZ_TOOLS_VER 3)
+set(GZ_TOOLS_VER 2)
 
 #--------------------------------------
 # Find gz-utils


### PR DESCRIPTION

# 🦟 Bug fix


## Summary

Set `GZ_TOOLS_VER` to 2.

This var is used in`./loader/conf/CMakeLists.txt` for determining the bash completion script installation path. It should now correctly install to `install/share/gz/gz2.completion.d/plugin3.bash_completion.sh`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

