### PR TITLE
Improve robustness to whitespace in gz_TEST

### DIFF
--- a/loader/src/gz_TEST.cc
+++ b/loader/src/gz_TEST.cc
@@ -58,26 +58,40 @@ std::string custom_exec_str(std::string _cmd)
 }
 
 //////////////////////////////////////////////////
+/// \brief Verify that two substrings are found within a larger string,
+/// separated only by spaces
+void verifySpaceSeparatedSubstrings(const std::string &_stringToSearch,
+                                    const std::string &_substring1,
+                                    const std::string &_substring2)
+{
+  auto iterator1 = _stringToSearch.find(_substring1);
+  EXPECT_NE(std::string::npos, iterator1)
+    << " failed to find \"" << _substring1 << "\" in:\n" << _stringToSearch;
+  ASSERT_LE(iterator1 + _substring1.size(), _stringToSearch.size());
+  auto iterator2 =
+      _stringToSearch.find_first_not_of(' ', iterator1 + _substring1.size());
+  EXPECT_NE(std::string::npos, iterator2);
+  ASSERT_LE(iterator2 + _substring2.size(), _stringToSearch.size());
+  EXPECT_EQ(_substring2, _stringToSearch.substr(iterator2, _substring2.size()));
+}
+
+//////////////////////////////////////////////////
 /// \brief Check 'gz plugin --help'.
-TEST(gzTest, IgnPluginHelp)
+TEST(gzTest, GzPluginHelp)
 {
   // Path to gz executable
   std::string gz = std::string(GZ_PATH);
   std::string output = custom_exec_str(gz + " plugin --help");
-  EXPECT_NE(std::string::npos,
-    output.find("-i [--info]                 Get info about a plugin."))
-      << output;
-  EXPECT_NE(std::string::npos,
-    output.find("-p [--plugin] TEXT          Path to a plugin."))
-      << output;
+  verifySpaceSeparatedSubstrings(
+      output, "-i [--info]", "Get info about a plugin.");
+  verifySpaceSeparatedSubstrings(
+      output, "-p [--plugin] TEXT", "Path to a plugin.");
 
   output = custom_exec_str(gz + " plugin");
-  EXPECT_NE(std::string::npos,
-    output.find("-i [--info]                 Get info about a plugin."))
-      << output;
-  EXPECT_NE(std::string::npos,
-    output.find("-p [--plugin] TEXT          Path to a plugin."))
-      << output;
+  verifySpaceSeparatedSubstrings(
+      output, "-i [--info]", "Get info about a plugin.");
+  verifySpaceSeparatedSubstrings(
+      output, "-p [--plugin] TEXT", "Path to a plugin.");
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION

# 🦟 Bug fix

Fixes #179

## Summary

The amount of indentation in `gz plugin --help` can vary, so add a helper function that looks for two substrings separated only by spaces and use it instead of hard-coding the expected amount of whitespace.

Backported from https://github.com/gazebosim/gz-plugin/commit/27be1bc461387e4da1644759dbfaf0ed0fcc6a78 in https://github.com/gazebosim/gz-plugin/pull/175.

cc @traversaro

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
